### PR TITLE
add support for renaming members

### DIFF
--- a/src/CsToTs/TypeScript/Helper.cs
+++ b/src/CsToTs/TypeScript/Helper.cs
@@ -156,15 +156,15 @@ namespace CsToTs.TypeScript {
         }
         
         private static IEnumerable<MemberDefinition> GetMembers(Type type, TypeScriptContext context) {
-            var memberRenamer = context.Options.MemberRenamer ?? new Func<string,string>(x => x);
+            var memberRenamer = context.Options.MemberRenamer ?? new Func<MemberInfo,string>(x => x.Name);
 
             var memberDefs = type.GetFields(BindingFlags)
-                .Select(f => new MemberDefinition(memberRenamer(f.Name), GetTypeRef(f.FieldType, context)))
+                .Select(f => new MemberDefinition(memberRenamer(f), GetTypeRef(f.FieldType, context)))
                 .ToList();
 
             memberDefs.AddRange(
                 type.GetProperties(BindingFlags)
-                    .Select(p => new MemberDefinition(memberRenamer(p.Name), GetTypeRef(p.PropertyType, context)))
+                    .Select(p => new MemberDefinition(memberRenamer(p), GetTypeRef(p.PropertyType, context)))
             );
             
             return memberDefs;
@@ -174,20 +174,20 @@ namespace CsToTs.TypeScript {
             var shouldGenerateMethod = context.Options.ShouldGenerateMethod;
             if (shouldGenerateMethod == null) return Enumerable.Empty<MethodDefinition>();
 
-            var memberRenamer = context.Options.MemberRenamer ?? new Func<string,string>(x => x);
+            var memberRenamer = context.Options.MemberRenamer ?? new Func<MemberInfo,string>(x => x.Name);
 
             var retVal = new List<MethodDefinition>();
             var methods = type.GetMethods(BindingFlags).Where(m => !m.IsSpecialName);
             foreach (var method in methods) {
                 string methodDeclaration;
                 if (method.IsGenericMethod) {
-                    var methodName = memberRenamer(method.Name);
+                    var methodName = memberRenamer(method);
                     
                     var genericPrms = method.GetGenericArguments().Select(t => GetTypeRef(t, context));
                     methodDeclaration = $"{methodName}<{string.Join(", ", genericPrms)}>";
                 }
                 else {
-                    methodDeclaration = memberRenamer(method.Name);
+                    methodDeclaration = memberRenamer(method);
                 }
 
                 var parameters = method.GetParameters()

--- a/src/CsToTs/TypeScriptOptions.cs
+++ b/src/CsToTs/TypeScriptOptions.cs
@@ -25,7 +25,7 @@ namespace CsToTs {
         public Func<Type, bool> UseInterfaceForClasses { get; set; }
         public Func<Type, string> DefaultBaseType { get; set; }
         public Func<string, string> TypeRenamer { get; set; }
-        public Func<string, string> MemberRenamer { get; set; }
+        public Func<MemberInfo, string> MemberRenamer { get; set; }
         public Func<Type, CtorDefinition> CtorGenerator { get; set; }
         public Func<MethodInfo, MethodDefinition, bool> ShouldGenerateMethod { get; set; }
     }

--- a/src/CsToTs/TypeScriptOptions.cs
+++ b/src/CsToTs/TypeScriptOptions.cs
@@ -25,6 +25,7 @@ namespace CsToTs {
         public Func<Type, bool> UseInterfaceForClasses { get; set; }
         public Func<Type, string> DefaultBaseType { get; set; }
         public Func<string, string> TypeRenamer { get; set; }
+        public Func<string, string> MemberRenamer { get; set; }
         public Func<Type, CtorDefinition> CtorGenerator { get; set; }
         public Func<MethodInfo, MethodDefinition, bool> ShouldGenerateMethod { get; set; }
     }

--- a/tests/CsToTs.Tests/TypeScriptTests.cs
+++ b/tests/CsToTs.Tests/TypeScriptTests.cs
@@ -177,6 +177,33 @@ namespace CsToTs.Tests {
         [Fact]
         public void ShouldRenameTypes() {
             var options = new TypeScriptOptions {
+                // convert to camel case
+                MemberRenamer = source => source.Substring(0, 1).ToLower() + source.Substring(1)
+            };
+            var gen = Generator.GenerateTypeScript(typeof(Company<>), options);
+
+            var address = GetGeneratedType(gen, "export class Address");
+            Assert.NotEmpty(address);
+            Assert.Contains("companyId: number", address);
+            Assert.Contains("city: string", address);
+            Assert.Contains("detail: string", address);
+            Assert.Contains("postalCode: number", address);
+
+            var company = GetGeneratedType(gen, "export class Company");
+            Assert.NotEmpty(company);
+            Assert.Contains("income: number", gen);
+            Assert.Contains("addresses: Array<TAddress>", company);
+            Assert.Contains("addressesArray: Array<TAddress>", company);
+            Assert.Contains("extends BaseEntity<number>", company);
+
+            var constraints = Regex.Match(company, "<.*?>").Value;
+            Assert.Contains("Address", constraints);
+            Assert.Contains("TAddress extends Address & { new(): TAddress }", constraints);
+        }
+
+        [Fact]
+        public void ShouldRenameMembers() {
+            var options = new TypeScriptOptions {
                 TypeRenamer = t => t == "BaseEntity" ? "EntityBase" : t 
             };
             var gen = Generator.GenerateTypeScript(typeof(Company<>), options);

--- a/tests/CsToTs.Tests/TypeScriptTests.cs
+++ b/tests/CsToTs.Tests/TypeScriptTests.cs
@@ -178,7 +178,7 @@ namespace CsToTs.Tests {
         public void ShouldRenameTypes() {
             var options = new TypeScriptOptions {
                 // convert to camel case
-                MemberRenamer = source => source.Substring(0, 1).ToLower() + source.Substring(1)
+                MemberRenamer = source => source.Name.Substring(0, 1).ToLower() + source.Name.Substring(1)
             };
             var gen = Generator.GenerateTypeScript(typeof(Company<>), options);
 


### PR DESCRIPTION
Allows the names of class members to be intercepted and renamed, useful for converting to camel case for example (shown in the tests).