### PR TITLE
add support for nullable/optional properties

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,11 +31,11 @@ test_script:
 - nuget install coveralls.net -Version 0.7.0 -OutputDirectory tools
 - .\tools\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i opencoverCoverage.xml --repoToken "%COVERALLS_REPO_TOKEN%" --useRelativePaths --commitId "%APPVEYOR_REPO_COMMIT%" --commitBranch "%APPVEYOR_REPO_BRANCH%" --commitAuthor "%APPVEYOR_REPO_COMMIT_AUTHOR%" --commitEmail "%APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL%" --commitMessage "%APPVEYOR_REPO_COMMIT_MESSAGE%" --jobId "%APPVEYOR_BUILD_NUMBER%" --serviceName appveyor
 
-deploy:
-  provider: NuGet
-  api_key:
-    secure: hQY0HMU8ADJvqFfivG/Z0+h2Nz8xFCFd64ERHhaTFc3SzRy3Kz8C3FE8tiJMqMjz
-  skip_symbols: false
-  artifact: /.CsToTs*\.nupkg/
-  on:
-    appveyor_repo_tag: true
+#deploy:
+#  provider: NuGet
+#  api_key:
+#    secure: hQY0HMU8ADJvqFfivG/Z0+h2Nz8xFCFd64ERHhaTFc3SzRy3Kz8C3FE8tiJMqMjz
+#  skip_symbols: false
+#  artifact: /.CsToTs*\.nupkg/
+#  on:
+#    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,5 +34,3 @@ deploy:
     secure: b157yk1rsget3bmhg26sktus
   skip_symbols: false
   artifact: /.CsToTs*\.nupkg/
-  on:
-    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,11 +31,12 @@ test_script:
 - nuget install coveralls.net -Version 0.7.0 -OutputDirectory tools
 - .\tools\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i opencoverCoverage.xml --repoToken "%COVERALLS_REPO_TOKEN%" --useRelativePaths --commitId "%APPVEYOR_REPO_COMMIT%" --commitBranch "%APPVEYOR_REPO_BRANCH%" --commitAuthor "%APPVEYOR_REPO_COMMIT_AUTHOR%" --commitEmail "%APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL%" --commitMessage "%APPVEYOR_REPO_COMMIT_MESSAGE%" --jobId "%APPVEYOR_BUILD_NUMBER%" --serviceName appveyor
 
-#deploy:
-#  provider: NuGet
-#  api_key:
-#    secure: hQY0HMU8ADJvqFfivG/Z0+h2Nz8xFCFd64ERHhaTFc3SzRy3Kz8C3FE8tiJMqMjz
-#  skip_symbols: false
-#  artifact: /.CsToTs*\.nupkg/
-#  on:
-#    appveyor_repo_tag: true
+deploy:
+  provider: NuGet
+  symbol_server: https://ci.appveyor.com/nuget/cs-to-ts-64r57smi2m2w/api/v2/package
+  api_key:
+    secure: b157yk1rsget3bmhg26sktus
+  skip_symbols: false
+  artifact: /.CsToTs*\.nupkg/
+  on:
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,6 @@ deploy:
   provider: NuGet
   symbol_server: https://ci.appveyor.com/nuget/cs-to-ts-64r57smi2m2w/api/v2/package
   api_key:
-    secure: b157yk1rsget3bmhg26sktus
+    secure: IY6yNKHo49GXJemOISi23ZvgFkt3YPlZYLKCHXkxvSQ=
   skip_symbols: false
   artifact: /.CsToTs*\.nupkg/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,10 +26,6 @@ after_build:
 
 test_script:
 - dotnet test -c %CONFIGURATION% tests\CsToTs.Tests\CsToTs.Tests.csproj
-- nuget install OpenCover -Version 4.6.519 -OutputDirectory tools
-- .\tools\OpenCover.4.6.519\tools\OpenCover.Console.exe -target:"c:\Program Files\dotnet\dotnet.exe" -targetargs:"test -f netcoreapp2.0 -c %CONFIGURATION% tests/CsToTs.Tests/CsToTs.Tests.csproj" -filter:"+[CsToTs*]* -[CsToTs.*Tests*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -output:opencoverCoverage.xml -oldStyle -register:user
-- nuget install coveralls.net -Version 0.7.0 -OutputDirectory tools
-- .\tools\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i opencoverCoverage.xml --repoToken "%COVERALLS_REPO_TOKEN%" --useRelativePaths --commitId "%APPVEYOR_REPO_COMMIT%" --commitBranch "%APPVEYOR_REPO_BRANCH%" --commitAuthor "%APPVEYOR_REPO_COMMIT_AUTHOR%" --commitEmail "%APPVEYOR_REPO_COMMIT_AUTHOR_EMAIL%" --commitMessage "%APPVEYOR_REPO_COMMIT_MESSAGE%" --jobId "%APPVEYOR_BUILD_NUMBER%" --serviceName appveyor
 
 deploy:
   provider: NuGet

--- a/src/CsToTs/TypeScript/MemberDefinition.cs
+++ b/src/CsToTs/TypeScript/MemberDefinition.cs
@@ -2,17 +2,19 @@
 using System.Linq;
 
 namespace CsToTs.TypeScript {
-    
+
     public class MemberDefinition {
 
-        public MemberDefinition(string name, string type, IEnumerable<string> decorators = null) {
+        public MemberDefinition(string name, string type, bool isNullable = false, IEnumerable<string> decorators = null) {
             Name = name;
             Type = type;
+            IsNullable = isNullable;
             Decorators = (decorators?.ToList() ?? new List<string>()).AsReadOnly();
         }
-        
+
         public string Name { get; }
         public string Type { get; }
+        public bool IsNullable { get; }
         public IReadOnlyCollection<string> Decorators { get; }
     }
 }

--- a/src/CsToTs/TypeScript/template.handlebars
+++ b/src/CsToTs/TypeScript/template.handlebars
@@ -1,11 +1,11 @@
 {{#Types}}
-    
+
 {{Declaration}} {
     {{#Members}}
     {{#Decorators}}
     {{.}}
     {{/Decorators}}
-    {{Name}}: {{Type}};
+    {{Name}}{{#IsNullable}}?{{/IsNullable}}: {{Type}};
     {{/Members}}
     {{#if Ctor}}
 

--- a/tests/CsToTs.Tests/Fixture/Address.cs
+++ b/tests/CsToTs.Tests/Fixture/Address.cs
@@ -6,5 +6,6 @@ namespace CsToTs.Tests.Fixture {
         public string Detail { get; set; }
         public long PostalCode;
         public bool? Overseas { get; set; }
+        public int? PoBox;
     }
 }

--- a/tests/CsToTs.Tests/Fixture/Address.cs
+++ b/tests/CsToTs.Tests/Fixture/Address.cs
@@ -5,5 +5,6 @@ namespace CsToTs.Tests.Fixture {
         public string City { get; set; }
         public string Detail { get; set; }
         public long PostalCode;
+        public bool? Overseas { get; set; }
     }
 }

--- a/tests/CsToTs.Tests/TypeScriptTests.cs
+++ b/tests/CsToTs.Tests/TypeScriptTests.cs
@@ -77,6 +77,7 @@ namespace CsToTs.Tests {
             Assert.Contains("Detail: string", address);
             Assert.Contains("PostalCode: number", address);
             Assert.Contains("Overseas?: boolean", address);
+            Assert.Contains("PoBox?: number", address);
 
             var company = GetGeneratedType(gen, "export class Company");
             Assert.NotEmpty(company);

--- a/tests/CsToTs.Tests/TypeScriptTests.cs
+++ b/tests/CsToTs.Tests/TypeScriptTests.cs
@@ -76,6 +76,7 @@ namespace CsToTs.Tests {
             Assert.Contains("City: string", address);
             Assert.Contains("Detail: string", address);
             Assert.Contains("PostalCode: number", address);
+            Assert.Contains("Overseas?: boolean", address);
 
             var company = GetGeneratedType(gen, "export class Company");
             Assert.NotEmpty(company);
@@ -236,7 +237,7 @@ namespace CsToTs.Tests {
         public void ShouldGenerateMethods() {
             var options = new TypeScriptOptions {
                 ShouldGenerateMethod = (m, md) => {
-                    md.Parameters.Add(new TypeScript.MemberDefinition("options", "AjaxOptions", new List<string>()));
+                    md.Parameters.Add(new TypeScript.MemberDefinition("options", "AjaxOptions", false, new List<string>()));
                     md.Lines.Add($"return window.ajax('{m.Name}')");
                     return true;
                 }


### PR DESCRIPTION
A c# property like this:
```cs
public int? Foo { get; set; }
```
should emit this typescript
```ts
Foo?: number;
```
