### PR TITLE
emit enums before types

### DIFF
--- a/src/CsToTs/TypeScript/template.handlebars
+++ b/src/CsToTs/TypeScript/template.handlebars
@@ -1,3 +1,12 @@
+{{#Enums}}
+
+export enum {{Name}} {
+    {{#Fields}}
+    {{Name}} = {{Value}},
+    {{/Fields}}
+}
+{{/Enums}}
+
 {{#Types}}
 
 {{Declaration}} {
@@ -27,12 +36,4 @@
     {{/Methods}}
 }
 {{/Types}}
-{{#Enums}}
-
-export enum {{Name}} {
-    {{#Fields}}
-    {{Name}} = {{Value}},
-    {{/Fields}}
-}
-{{/Enums}}
 


### PR DESCRIPTION
I get warnings with my typescript configuration if the types are declared before the enums.

This switches the order to enums, then types.