### PR TITLE
Allow outputing enums as string values

### DIFF
--- a/src/CsToTs/TypeScript/Helper.cs
+++ b/src/CsToTs/TypeScript/Helper.cs
@@ -141,7 +141,7 @@ namespace CsToTs.TypeScript {
             if (existing != null) return existing;
 
             var members = Enum.GetNames(type)
-                .Select(n => new EnumField(n, Convert.ToInt32(Enum.Parse(type, n)).ToString()));
+                .Select(n => new EnumField(n, context.Options.UseStringsForEnums ? $"\"{n}\"" : Convert.ToInt32(Enum.Parse(type, n)).ToString()));
 
             var def = new EnumDefinition(type, ApplyRename(type.Name, context), members);
             context.Enums.Add(def);

--- a/src/CsToTs/TypeScriptOptions.cs
+++ b/src/CsToTs/TypeScriptOptions.cs
@@ -22,6 +22,7 @@ namespace CsToTs {
         }
 
         public bool UseDateForDateTime { get; set; }
+        public bool UseStringsForEnums { get; set; }
         public Func<Type, bool> UseInterfaceForClasses { get; set; }
         public Func<Type, string> DefaultBaseType { get; set; }
         public Func<string, string> TypeRenamer { get; set; }

--- a/tests/CsToTs.Tests/Fixture/EntityWithCollections.cs
+++ b/tests/CsToTs.Tests/Fixture/EntityWithCollections.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace CsToTs.Tests.Fixture
+{
+    public class EntityWithCollections
+    {
+        public IEnumerable<string> IEnumerableOfStrings { get; set; }
+        public IDictionary<string, int> IDictionaryOfStringsToNumbers { get; set; }
+        public Dictionary<string, int> DictionaryOfStringsToNumbers { get; set; }
+    }
+}

--- a/tests/CsToTs.Tests/Fixture/EntityWithEnum.cs
+++ b/tests/CsToTs.Tests/Fixture/EntityWithEnum.cs
@@ -1,0 +1,7 @@
+﻿namespace CsToTs.Tests.Fixture
+{
+    public class EntityWithEnum
+    {
+        public TypeEnum Enum { get; set; }
+    }
+}

--- a/tests/CsToTs.Tests/TypeScriptTests.cs
+++ b/tests/CsToTs.Tests/TypeScriptTests.cs
@@ -55,6 +55,21 @@ namespace CsToTs.Tests {
         }
 
         [Fact]
+        public void ShouldGenerateStringsForEnumsWhenConfigured()
+        {
+            TypeScriptOptions options = new TypeScriptOptions
+            {
+                UseStringsForEnums = true
+            };
+            var gen = Generator.GenerateTypeScript(options, typeof(EntityWithEnum));
+
+            var typeEnum = GetGeneratedType(gen, "export enum TypeEnum");
+
+            Assert.NotEmpty(typeEnum);
+            Assert.Contains("Type1 = \"Type1\"", typeEnum);
+            Assert.Contains("Type2 = \"Type2\"", typeEnum);
+        }
+        [Fact]
         public void ShouldGenerateOpenForClosedGenericClass() {
             var gen = Generator.GenerateTypeScript(typeof(BaseEntity<int>));
 

--- a/tests/CsToTs.Tests/TypeScriptTests.cs
+++ b/tests/CsToTs.Tests/TypeScriptTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using CsToTs.Tests.Fixture;
@@ -69,6 +70,35 @@ namespace CsToTs.Tests {
             Assert.Contains("Type1 = \"Type1\"", typeEnum);
             Assert.Contains("Type2 = \"Type2\"", typeEnum);
         }
+
+        [Fact]
+        public void ShouldGenerateMembersWithCamelCaseWhenConfigured()
+        {
+            TypeScriptOptions options = new TypeScriptOptions
+            {
+                MemberRenamer = info => new Regex("^.").Replace(info.Name, match => match.Value.ToLowerInvariant())
+            };
+            var gen = Generator.GenerateTypeScript(options, typeof(Address));
+            var address = GetGeneratedType(gen, "export class Address");
+            Assert.NotEmpty(address);
+            Assert.Contains("companyId: number", address);
+            Assert.Contains("city: string", address);
+            Assert.Contains("detail: string", address);
+            Assert.Contains("postalCode: number", address);
+            Assert.Contains("overseas?: boolean", address);
+            Assert.Contains("poBox?: number", address);
+        }
+        [Fact]
+        public void ShouldGenerateMembersWithCollections()
+        {
+            var gen = Generator.GenerateTypeScript(typeof(EntityWithCollections));
+            var address = GetGeneratedType(gen, "export class EntityWithCollections");
+            Assert.NotEmpty(address);
+            Assert.Contains("EnumerableOfStrings: Array<string>", address);
+            Assert.Contains("IDictionaryOfStringsToNumbers: Record<string, number>", address);
+            Assert.Contains("DictionaryOfStringsToNumbers: Record<string, number>", address);
+        }
+
         [Fact]
         public void ShouldGenerateOpenForClosedGenericClass() {
             var gen = Generator.GenerateTypeScript(typeof(BaseEntity<int>));


### PR DESCRIPTION
Hi,

I'm looking at this as an option to output our DTOs and service models to typescript, and one thing I've noticed is that enums are rendered as integers.

I've spiked an option to output as strings, with a simple test. 

Would this be a valid contribution? Or is there another way to acomplish this?
I'm hardcoding "" instead of '', not sure if that's valid.

Thanks