### PR TITLE
No longer crash when generating the types for a subclass of Dictionary<>

### DIFF
--- a/src/CsToTs/TypeScript/Helper.cs
+++ b/src/CsToTs/TypeScript/Helper.cs
@@ -244,8 +244,8 @@ namespace CsToTs.TypeScript {
 
             if (dictionaryType != null)
             {
-                var keyType = type.GetGenericArguments().ElementAt(0);
-                var valueType = type.GetGenericArguments().ElementAt(1);
+                var keyType = dictionaryType.GetGenericArguments().ElementAt(0);
+                var valueType = dictionaryType.GetGenericArguments().ElementAt(1);
                 return $"Record<{GetTypeRef(keyType, context)}, {GetTypeRef(valueType, context)}>";
             }
 

--- a/tests/CsToTs.Tests/Fixture/DictionarySubclass.cs
+++ b/tests/CsToTs.Tests/Fixture/DictionarySubclass.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace CsToTs.Tests.Fixture
+{
+    class SubclassOfDictionary : Dictionary<string, string>
+    {
+    }
+
+    class ClassWithSubclassOfDictionary
+    {
+        public SubclassOfDictionary AProperty { get; set; }
+    }
+}

--- a/tests/CsToTs.Tests/TypeScriptTests.cs
+++ b/tests/CsToTs.Tests/TypeScriptTests.cs
@@ -334,6 +334,14 @@ namespace CsToTs.Tests {
             Assert.Equal(3, GetTypeCount(gen));
         }
 
+        [Fact]
+        public void IsTheProblemWithDictionaryObjects() {
+            var gen = Generator.GenerateTypeScript(typeof(ClassWithSubclassOfDictionary));
+
+            var containerClass = GetGeneratedType(gen, @"export class ClassWithSubclassOfDictionary");
+            Assert.Contains("AProperty: Record<string, string>;", containerClass);
+        }
+
         private static string GetGeneratedType(string generated, string declaration) {
             var match = Regex.Match(generated, declaration + @".*?(export|$)", RegexOptions.Singleline);
 


### PR DESCRIPTION
This library crashed when we tried to generate the typescript for a class which subclassed dictionary.

It looked like a typo. We added a test, and it seems to fix it. Not sure if it's the best way to convert these cases, but at least it no longer crashes.

Would this be PR be acceptable?

Thanks!