### PR TITLE
Added TypeMapOverride option to customize type mapping

### DIFF
--- a/src/CsToTs/TypeScript/Helper.cs
+++ b/src/CsToTs/TypeScript/Helper.cs
@@ -224,6 +224,10 @@ namespace CsToTs.TypeScript {
         }
 
         private static string GetTypeRef(Type type, TypeScriptContext context) {
+            var typeOverride = context.Options.TypeMapOverride?.Invoke(type);
+            if (typeOverride != null)
+                return typeOverride;
+
             if (type.IsGenericParameter)
                 return type.Name;
 

--- a/src/CsToTs/TypeScriptOptions.cs
+++ b/src/CsToTs/TypeScriptOptions.cs
@@ -30,5 +30,6 @@ namespace CsToTs {
         public Func<Type, CtorDefinition> CtorGenerator { get; set; }
         public Func<MethodInfo, MethodDefinition, bool> ShouldGenerateMethod { get; set; }
         public Func<MemberInfo, IEnumerable<string>> UseDecorators { get; set; }
+        public Func<Type, string> TypeMapOverride { get; set; }
     }
 }

--- a/tests/CsToTs.Tests/Fixture/EntityWithMoreTypes.cs
+++ b/tests/CsToTs.Tests/Fixture/EntityWithMoreTypes.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Net;
+
+namespace CsToTs.Tests.Fixture
+{
+    public class EntityWithMoreTypes
+    {
+        public DateTimeOffset DateTimeOffset { get; set; }
+        public JObject JObject { get; set; }
+        public HttpStatusCode HttpStatusCode { get; set; }
+        public Guid Guid { get; set; }
+    }
+}

--- a/tests/CsToTs.Tests/TypeScriptTests.cs
+++ b/tests/CsToTs.Tests/TypeScriptTests.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 using CsToTs.Tests.Fixture;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace CsToTs.Tests {
@@ -340,6 +343,28 @@ namespace CsToTs.Tests {
 
             var containerClass = GetGeneratedType(gen, @"export class ClassWithSubclassOfDictionary");
             Assert.Contains("AProperty: Record<string, string>;", containerClass);
+        }
+
+        [Fact]
+        public void ShouldOverrideTypes()
+        {
+            var dict = new Dictionary<Type, string>
+            {
+                {typeof(DateTimeOffset), "Date"},
+                {typeof(JObject), "Record<string, any>"},
+                {typeof(HttpStatusCode), "number"},
+                {typeof(Guid), "string"},
+            };
+
+            var output = Generator.GenerateTypeScript(typeof(EntityWithMoreTypes), new TypeScriptOptions
+            {
+                TypeMapOverride = t => dict.TryGetValue(t, out var mappedType) ? mappedType : null
+            });
+
+            Assert.Contains("DateTimeOffset: Date", output);
+            Assert.Contains("JObject: Record<string, any>", output);
+            Assert.Contains("HttpStatusCode: number", output);
+            Assert.Contains("Guid: string", output);
         }
 
         private static string GetGeneratedType(string generated, string declaration) {


### PR DESCRIPTION
Wanted to be able to support additional logic to map types that might not be implemented. This change allows anyone to manually add a type override option.